### PR TITLE
remove all the warnings when running the app

### DIFF
--- a/app.py
+++ b/app.py
@@ -238,7 +238,7 @@ def fig_sankey(year, region):
                     ]
                 ]
             )
-            df = df.drop("Exports").append(df2)
+            df = pd.concat([df.drop("Exports"), df2])
 
         if node in [
             "Africa",
@@ -269,7 +269,7 @@ def fig_sankey(year, region):
                     ]
                 ]
             )
-            df = df.append(df2)
+            df = pd.concat([df, df2])
             df3 = (
                 nodes.reset_index()
                 .set_index(["position", "index"])
@@ -461,25 +461,25 @@ def fig_sankey(year, region):
             y=lambda d: [node_y(nodes, i, white, color, region) for i in d.index],
         )
 
-        nodes["x"].loc["Exports"] = 0.65
+        nodes.loc["x", "Exports"] = 0.65
         try:
-            nodes["x"].loc["CFC imports re-exported"] = 0.65
+            nodes.loc["x", "CFC imports re-exported"] = 0.65
         except KeyError:
             None
 
         try:
-            nodes["x"].loc["RoW - Negative capital formation"] = 0.38
+            nodes.loc["x", "RoW - Negative capital formation"] = 0.38
         except KeyError:
             None
 
         try:
-            nodes["x"].loc["Negative capital formation"] = 0.38
+            nodes.loc["x", "Negative capital formation"] = 0.38
         except KeyError:
             None
         # nodes["x"].loc[["CFC","RoW - CFC"]] = 0.76
         # nodes["x"].loc[["CFCk","RoW - CFCk"]] = 0.76
 
-        nodes["x"].loc[
+        nodes.loc["x", 
             [
                 "RoW - Mobility",
                 "RoW - Shelter",


### PR DESCRIPTION
Few minor updates in the code that are not intended to have any functionnal change, but that remove a bunch of warnings cluttering the logs: 

- `The series.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.`
- `A value is trying to be set on a copy of a slice from a DataFrame, See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy`