### PR TITLE
Update Scalingo URL to include utm tags

### DIFF
--- a/index.py
+++ b/index.py
@@ -16,7 +16,7 @@ from apps import app_sankey, app_sankey_per_capita, doc
 # auth = BasicAuth(app, VALID_USERNAME_PASSWORD_PAIRS)
 
 thanks = html.Div(
-    html.P(["Graciously hosted by ", html.A("scalingo", href="https://scalingo.com", target="_blank"), " in 🇫🇷"]),
+    html.P(["Graciously hosted by ", html.A("scalingo", href="https://scalingo.com?utm_source=referral&utm_medium=website-footer&utm_campaign=shiftproject", target="_blank"), " in 🇫🇷"]),
     id="thanks",
     # justify="right",
 )


### PR DESCRIPTION
Scalingo asked us if we could include UTM tags on their URL, to track campaign clicks. 